### PR TITLE
Define Etherpad plugins to install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -204,6 +204,7 @@ etherpad_database_connection_string: 'postgres://{{ etherpad_database_username }
 etherpad_title: 'Etherpad'
 etherpad_abiword: null
 etherpad_soffice: null
+etherpad_plugins: []
 etherpad_default_pad_text: |
   Welcome to Etherpad!
 

--- a/docs/configuring-etherpad.md
+++ b/docs/configuring-etherpad.md
@@ -123,6 +123,21 @@ etherpad_default_pad_text: |
   Get involved with Etherpad at https://etherpad.org
 ```
 
+### Define plugins to install (optional)
+
+You can also define plugins that should be installed with the variable `etherpad_plugins`. Defining plugins also requires self-building the Etherpad Docker image with the `etherpad_container_image_self_build` variable.
+
+Etherpad plugins can also be managed from the admin page (if enabled). You can view a list of all Etherpad plugins [here](https://static.etherpad.org/index.html). 
+
+To specify plugins to install, add the following configuration to your `vars.yml` file (adapt to your needs). No plugins are installed by default.
+
+```yaml
+etherpad_container_image_self_build: true
+etherpad_plugins:
+  - YOUR_FIRST_PLUGIN_HERE
+  - YOUR_SECOND_PLUGIN_HERE
+```
+
 ### Extending the configuration
 
 There are some additional things you may wish to configure about the component.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -76,6 +76,7 @@
         chdir: "{{ etherpad_container_src_path }}"
         cmd: |
           {{ devture_systemd_docker_base_host_command_docker }} build \
+          --build-arg ETHERPAD_PLUGINS="{{ etherpad_plugins|join(' ') }}" \
           -t "{{ etherpad_container_image }}" \
           -f Dockerfile \
           .


### PR DESCRIPTION
This feature allows Etherpad plugins to be installed through the playbook. This also solves a problem I'd been experiencing where all the Etherpad plugins I'd previously installed are removed after re-running the playbook.