### PR TITLE
Remove unused settings from etherpad.service.j2

### DIFF
--- a/templates/systemd/etherpad.service.j2
+++ b/templates/systemd/etherpad.service.j2
@@ -35,15 +35,12 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --label-file={{ etherpad_base_path }}/labels \
       --health-interval={{ etherpad_container_health_interval }} \
       --mount type=bind,src={{ etherpad_config_path }},dst=/config,ro \
-      --mount type=bind,src={{ etherpad_data_path }},dst=/data \
       {% for arg in etherpad_container_extra_arguments %}
       {{ arg }} \
       {% endfor %}
       {{ etherpad_container_image_self_build_name if etherpad_container_image_self_build else etherpad_container_image }} \
       pnpm run prod \
-        --settings /config/settings.json \
-        --credentials /data/credentials.json \
-        --apikey /data/apikey.json
+        --settings /config/settings.json
 
 {% for network in etherpad_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ etherpad_identifier }}


### PR DESCRIPTION
Fixes https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4556

- we don't generate credentials.json (though we could - why not in /config?)
- same for apikey.json
- without them, /data seems completely unused